### PR TITLE
fix actionlint warning

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag reviewdog-actionlint:$(date +%s)
+      run: docker build . --file Dockerfile --tag "reviewdog-actionlint:$(date +%s)"


### PR DESCRIPTION
SC2046:warning:1:61: Quote this to prevent word splitting [shellcheck]