### PR TITLE
Fix --fail-on-error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,3 +12,6 @@ actionlint -oneline ${INPUT_ACTIONLINT_FLAGS} \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
         -level="${INPUT_LEVEL}" \
         ${INPUT_REVIEWDOG_FLAGS}
+exit_code=$?
+
+exit $exit_code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
+# shellcheck disable=SC2086
 actionlint -oneline ${INPUT_ACTIONLINT_FLAGS} \
     | reviewdog \
         -efm="%f:%l:%c: %m" \


### PR DESCRIPTION
The `--fail-on-error` option doesn't work because `entrypoint.sh` doesn't check the exit code of reviewdog.