### PR TITLE
configure the permissions of workflows

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -6,6 +6,11 @@ on:
     types: [depup]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,13 @@ name: Docker Image CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag "reviewdog-actionlint:$(date +%s)"
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag "reviewdog-actionlint:$(date +%s)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
   release:
     if: ${{ github.event.action != 'labeled' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v2
         with:
@@ -45,6 +49,10 @@ jobs:
   release-check:
     if: "${{ github.event.action == 'labeled' }}"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,6 +1,13 @@
 
 name: reviewdog
 on: [pull_request]
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+  issues: write
+
 jobs:
   actionlint:
     name: runner / actionlint


### PR DESCRIPTION
Workflows sometimes don't work correctly, because [workflows triggered by Dependabot to run with a read-only token](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/).

Starting October 11, 2021, [Workflows triggered by Dependabot PRs will respect permissions key in workflows](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/).
In order to benefit from this update, you need to set the permissions correctly.
