### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Release tags must be reachable from HEAD because the bump comment uses `git tag --merged`:
+      # https://github.com/haya14busa/bump/blob/9ab5412f5d96eb624c7e8559acbb11330be9901a/main.go#L72
+      - name: checkout to release branch
+        run: |
+          git branch -b "release/$(cat .major-version)" "origin/$(cat .major-version)"
+
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
       - id: bumpr
@@ -34,6 +40,7 @@ jobs:
       - name: build the Docker Image
         if: "${{ !steps.bumpr.outputs.skip }}"
         run: |
+          git checkout main
           ./.github/build.sh
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       # https://github.com/haya14busa/bump/blob/9ab5412f5d96eb624c7e8559acbb11330be9901a/main.go#L72
       - name: checkout to release branch
         run: |
-          git branch -b "release/$(cat .major-version)" "origin/$(cat .major-version)"
+          git checkout -b "release/$(cat .major-version)" "origin/$(cat .major-version)"
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
@@ -72,7 +72,7 @@ jobs:
       # https://github.com/haya14busa/bump/blob/9ab5412f5d96eb624c7e8559acbb11330be9901a/main.go#L72
       - name: checkout to release branch
         run: |
-          git branch -b "release/$(cat .major-version)" "origin/$(cat .major-version)"
+          git checkout -b "release/$(cat .major-version)" "origin/$(cat .major-version)"
 
       - name: Post bumpr status comment
         uses: haya14busa/action-bumpr@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       # https://github.com/haya14busa/bump/blob/9ab5412f5d96eb624c7e8559acbb11330be9901a/main.go#L72
       - name: checkout to release branch
         run: |
-          git checkout -b "release/$(cat .major-version)" "origin/$(cat .major-version)"
+          git checkout -b "releases/$(cat .major-version)" "origin/releases/$(cat .major-version)"
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
@@ -72,7 +72,7 @@ jobs:
       # https://github.com/haya14busa/bump/blob/9ab5412f5d96eb624c7e8559acbb11330be9901a/main.go#L72
       - name: checkout to release branch
         run: |
-          git checkout -b "release/$(cat .major-version)" "origin/$(cat .major-version)"
+          git checkout -b "releases/$(cat .major-version)" "origin/releases/$(cat .major-version)"
 
       - name: Post bumpr status comment
         uses: haya14busa/action-bumpr@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      # Release tags must be reachable from HEAD because the bump comment uses `git tag --merged`:
+      # https://github.com/haya14busa/bump/blob/9ab5412f5d96eb624c7e8559acbb11330be9901a/main.go#L72
+      - name: checkout to release branch
+        run: |
+          git branch -b "release/$(cat .major-version)" "origin/$(cat .major-version)"
+
       - name: Post bumpr status comment
         uses: haya14busa/action-bumpr@v1


### PR DESCRIPTION
The release workflow doesn't work correctly.

```
+ git config user.name shogo82148
+ git config user.email shogo82148@users.noreply.github.com
++ git rev-parse --abbrev-ref HEAD
+ CURRENT_BRANCH=main
+ echo v1
+ git add .major-version
+ git commit -m 'bump v1'
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
+ true
+ git push origin main
Everything up-to-date
+ git checkout -b releases/v1 origin/releases/v1
Switched to a new branch 'releases/v1'
branch 'releases/v1' set up to track 'origin/releases/v1'.
+ git merge -X theirs --no-ff -m 'Merge branch '\''main'\'' into releases/v1' main
Merge made by the 'ort' strategy.
 Dockerfile | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
+ git checkout main -- action.yml
+ perl -i -pe 's(image:\s*["'\'']?Dockerfile["'\'']?)(image: '\''docker://ghcr.io/reviewdog/action-actionlint:v1.37.0'\'')' action.yml
+ git add action.yml
+ git commit -m 'bump v1.37.0'
On branch releases/v1
Your branch is ahead of 'origin/releases/v1' by 5 commits.
  (use "git push" to publish your local commits)
```

This pull request fixes it.