### PR TITLE
Bump actionlint to 1.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV REVIEWDOG_VERSION=v0.17.4
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
 # install actionlint
-ENV ACTIONLINT_VERSION=1.6.27
+ENV ACTIONLINT_VERSION=1.7.0
 ENV OSTYPE=linux-gnu
 RUN cd /usr/local/bin/ && wget -O - -q https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | sh -s -- ${ACTIONLINT_VERSION}
 


### PR DESCRIPTION
Closes #125 due to new actionlint release: https://github.com/reviewdog/action-actionlint/issues/125#issuecomment-2101032555