### PR TITLE
README: remove a invalid input

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ actions with different config.
 Optional. Report level for reviewdog [info,warning,error].
 It's same as `-level` flag of reviewdog.
 
-### `workdir`
-
-Optional. Working directory relative to the root directory.
-
 ### `reporter`
 
 Optional. Reporter of reviewdog command [github-pr-check,github-pr-review].


### PR DESCRIPTION
I remove a input `workdir` from `README.md` because it is invalid input.