### PR TITLE
Fix flags with spaces

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ actionlint -oneline ${INPUT_ACTIONLINT_FLAGS} \
         -filter-mode="${INPUT_FILTER_MODE}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
         -level="${INPUT_LEVEL}" \
-        ${INPUT_REVIEWDOG_FLAGS}
+        "${INPUT_REVIEWDOG_FLAGS}"
 exit_code=$?
 
 exit $exit_code


### PR DESCRIPTION
Add quotes around flags, which enables flags like `-diff="git diff origin main"`.

TODO: Test with multiple flags.

First issue, actionlint breaks when there's no flags (aka files) passed.