### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,15 @@ It's same as `-reporter` flag of reviewdog.
 Optional. Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
 Default is file.
 
+### `fail_level`
+
+Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Possible values: [`none`, `any`, `info`, `warning`, `error`]
+Default is `none`.
+
 ### `fail_on_error`
 
+Deprecated, use `fail_level` instead.
 Optional.  Exit code for reviewdog when errors are found [true,false]
 Default is `false`.
 

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,18 @@ inputs:
       Default is file.
     default: 'file'
     required: true
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
     required: true
   reviewdog_flags:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ actionlint -oneline ${INPUT_ACTIONLINT_FLAGS} \
         -name="${INPUT_TOOL_NAME}" \
         -reporter="${INPUT_REPORTER}" \
         -filter-mode="${INPUT_FILTER_MODE}" \
+        -fail-level="${INPUT_FAIL_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
         -level="${INPUT_LEVEL}" \
         ${INPUT_REVIEWDOG_FLAGS}


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply this to `action-shellcheck`.