### PR TITLE
chore: migrate Renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "labels": [
     "bump:patch"


### PR DESCRIPTION
## Summary
- migrate Renovate's deprecated `config:base` preset to `config:recommended`
- keep the existing `bump:patch` label behavior unchanged

## Context
The open Dependency Dashboard (#198) reports `Config Migration Needed`. This is a narrow public-config cleanup so Renovate can stop flagging the deprecated preset.

## Validation
- `python3 -m json.tool .github/renovate.json`
